### PR TITLE
Fix ngOnDestroy crash when $modal is not init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,4 @@ _Pvt_Extensions
 /ng2-bs3-modal.*
 src/**.*.js
 src/**.*.d.ts
+.idea/

--- a/src/ng2-bs3-modal/components/modal.ts
+++ b/src/ng2-bs3-modal/components/modal.ts
@@ -46,8 +46,10 @@ export class ModalComponent implements OnDestroy {
     }
 
     ngOnDestroy() {
-        this.$modal.data('bs.modal', null);
-        this.$modal.remove();
+        if(this.$modal) {
+            this.$modal.data('bs.modal', null);
+            this.$modal.remove();
+        }
     }
 
     open(size?: string) {


### PR DESCRIPTION
- Fix ngOnDestroy crash when $modal is not init
- Ignore IntelliJ .idea/…project files