### PR TITLE
package: Fix script bin invocations

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,18 +5,18 @@
   "main": "ng2-bs3-modal.js",
   "scripts": {
     "peer": "npm install es6-promise@^3.0.2 es6-shim@^0.33.3 reflect-metadata@0.1.2 rxjs@5.0.0-beta.0 zone.js@0.5.14",
-    "lint": "node ./node_modules/.bin/tslint ./src/**/*.ts",
-    "clean": "node ./node_modules/.bin/rimraf ./bundles/ ./components/ ./directives/ ./ng2-bs3-modal.js ./ng2-bs3-modal.d.ts",
-    "tsc": "node ./node_modules/.bin/tsc --project . --declaration",
-    "tsc-test": "node ./node_modules/.bin/tsc --project ./test",
-    "tsc-single": "node ./node_modules/.bin/tsc --project . --rootDir ./src --module system --outFile ./bundles/ng2-bs3-modal.js",
-    "uglify": "node ./node_modules/.bin/uglifyjs ./bundles/ng2-bs3-modal.js --output ./bundles/ng2-bs3-modal.min.js",
+    "lint": "tslint ./src/**/*.ts",
+    "clean": "rimraf ./bundles/ ./components/ ./directives/ ./ng2-bs3-modal.js ./ng2-bs3-modal.d.ts",
+    "tsc": "tsc --project . --declaration",
+    "tsc-test": "tsc --project ./test",
+    "tsc-single": "tsc --project . --rootDir ./src --module system --outFile ./bundles/ng2-bs3-modal.js",
+    "uglify": "uglifyjs ./bundles/ng2-bs3-modal.js --output ./bundles/ng2-bs3-modal.min.js",
     "bundles": "npm run tsc-single && npm run uglify",
     "build": "npm run clean && npm run typings && npm run lint && npm run tsc && npm run bundles",
     "prepublish": "npm run build",
-    "typings": "node ./node_modules/.bin/typings install",
-    "test": "node ./node_modules/.bin/karma start --single-run",
-    "test-watch": "node ./node_modules/.bin/karma start"
+    "typings": "typings install",
+    "test": "karma start --single-run",
+    "test-watch": "karma start"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It is always wrong to invoke node scripts in package.json using `node ./node_modules/.bin/xyz`.  Here's why:

1. It's unnecessary.  npm already puts `./node_modules/.bin` in the `PATH` environment variable when running scripts, and also ensures that scripts in that folder are executable.
2. It will break if the dependency is installed at a higher level.  In that case, it could actually be found at `../../node_modules/.bin` or some such.  npm also handles this for you, again using the `PATH` environment variable.
3. It [breaks on windows](https://github.com/isaacs/rimraf/issues/107).  Because Windows does not support shebang `#!/blah` style scripts natively, npm writes a `*.cmd` file for use with the cmd.exe program, and a shell script for use with msysgit bash and cygwin.  If you try to invoke either of these with node, it'll fail, because `./node_modules/.bin/tsc` is not a node program on Windows, but rather a shim that knows where to find the node program.

Tell your friends!  It solves no problem, and can only cause bugs.  Please remove `node ./node_modules/.bin/` from package.json scripts.

Thank you.