### PR TITLE
Limit autofocus directive to modals only

### DIFF
--- a/src/ng2-bs3-modal/directives/autofocus.ts
+++ b/src/ng2-bs3-modal/directives/autofocus.ts
@@ -2,7 +2,7 @@ import { Directive, ElementRef } from '@angular/core';
 import { ModalComponent } from '../components/modal';
 
 @Directive({
-    selector: '[autofocus]'
+    selector: 'modal[autofocus]'
 })
 export class AutofocusDirective {
     constructor(private el: ElementRef, private modal: ModalComponent) {


### PR DESCRIPTION
Not limiting the autofocus directive to modals means that Angular2 will try to apply the directive whenever you use the [HTML5 autofocus attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autofocus). This can cause dependency injection errors as there may not be a provider for the `ModalComponent` in the `AutofocusDirective`.