### PR TITLE
Declaring @NgModule That Exports Directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,16 @@ System.config({
 });
 ```
 
-Then import and include in your component's directives:
+Support for declaring `directives` on components was dropped in *Angular 2.0.0-rc.6*. The `ng2-bs3-modal` module must now be imported into consuming modules:
 
 ```typescript
-import { MODAL_DIRECTIVES } from 'ng2-bs3-modal/ng2-bs3-modal';
+import { Ng2Bs3ModalModule } from 'ng2-bs3-modal/ng2-bs3-modal';
 
-@Component({
-    directives: [MODAL_DIRECTIVES]
+@NgModule({
+    imports: [ Ng2Bs3ModalModule ]
+    ...
 })
-export class MyComponent {
-    ...    
-}
+export class MyApplicationModule { }
 ```
 
 See examples for [npm](https://github.com/dougludlow/ng2-bs3-modal-demo-npm), [SystemJS](https://github.com/dougludlow/ng2-bs3-modal-demo-systemjs), [jspm](https://github.com/dougludlow/ng2-bs3-modal-demo-jspm), and [angular-cli](https://github.com/dougludlow/ng2-bs3-modal/issues/31).

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   },
   "homepage": "https://github.com/dougludlow/ng2-bs3-modal#readme",
   "devDependencies": {
-    "@angular/common": "^2.0.0-rc.4",
-    "@angular/compiler": "^2.0.0-rc.4",
-    "@angular/core": "^2.0.0-rc.4",
-    "@angular/platform-browser": "^2.0.0-rc.4",
-    "@angular/platform-browser-dynamic": "^2.0.0-rc.4",
+    "@angular/common": "2.0.0-rc.5",
+    "@angular/compiler": "2.0.0-rc.5",
+    "@angular/core": "2.0.0-rc.5",
+    "@angular/platform-browser": "2.0.0-rc.5",
+    "@angular/platform-browser-dynamic": "2.0.0-rc.5",
     "@angular/router": "3.0.0-beta.2",
     "bootstrap": "^3.3.6",
     "es6-shim": "^0.35.0",
@@ -62,11 +62,11 @@
     "zone.js": "^0.6.12"
   },
   "peerDependencies": {
-    "@angular/common": "^2.0.0-rc.1",
-    "@angular/compiler": "^2.0.0-rc.1",
-    "@angular/core": "^2.0.0-rc.1",
-    "@angular/platform-browser": "^2.0.0-rc.1",
-    "@angular/platform-browser-dynamic": "^2.0.0-rc.1",
+    "@angular/common": "2.0.0-rc.5",
+    "@angular/compiler": "2.0.0-rc.5",
+    "@angular/core": "2.0.0-rc.5",
+    "@angular/platform-browser": "2.0.0-rc.5",
+    "@angular/platform-browser-dynamic": "2.0.0-rc.5",
     "bootstrap": "~3.3.x"
   }
 }

--- a/src/ng2-bs3-modal/ng2-bs3-modal.ts
+++ b/src/ng2-bs3-modal/ng2-bs3-modal.ts
@@ -12,7 +12,7 @@ export * from './components/modal-body';
 export * from './components/modal-footer';
 export * from './components/modal-instance';
 
-export const MODAL_DIRECTIVES: Type[] = [
+export const MODAL_DIRECTIVES: Type<any>[] = [
     ModalComponent,
     ModalHeaderComponent,
     ModalBodyComponent,

--- a/src/ng2-bs3-modal/ng2-bs3-modal.ts
+++ b/src/ng2-bs3-modal/ng2-bs3-modal.ts
@@ -1,4 +1,4 @@
-import { Type } from '@angular/core';
+import { NgModule, Type } from '@angular/core';
 
 import { ModalComponent } from './components/modal';
 import { ModalHeaderComponent } from './components/modal-header';
@@ -19,3 +19,9 @@ export const MODAL_DIRECTIVES: Type<any>[] = [
     ModalFooterComponent,
     AutofocusDirective
 ];
+
+@NgModule({
+    declarations: MODAL_DIRECTIVES,
+    exports: MODAL_DIRECTIVES
+})
+export class Ng2Bs3ModalModule { }


### PR DESCRIPTION
As per issue #96, the ng2-bs3-modal now publishes a `@NgModule` which exports the modal directives.

The README.md file has been updated to reflect this as part of the setup.

The examples projects will need updating to use the `@NgModule`. I'll go through and update those once this PR is merged.