### PR TITLE
Correct example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Then include the module in the `imports` collection of your app's module:
 
 ```typescript
 import { NgModule } from '@angular/core';
-import { Ng2Bs3ModalModule } from 'ng2-bs3-modal/ng2-bs3-modal';
+import { BsModalModule } from 'ng2-bs3-modal/ng2-bs3-modal';
 
 @NgModule({
     imports: [ BsModalModule ]


### PR DESCRIPTION
The README.md file contains a simple example of importing the `BsModalModule` into your own `NgModule`. 

However, the example still imported the module from `ng2-bs3-modal/ng2-bs3-modal` under the old name `Ng2Bs3ModalModule`. This was changed in the uber-commit https://github.com/dougludlow/ng2-bs3-modal/commits/3b56f6128774fc21fe4d6f6d0bfcbf2c2d8060fe to `BsModalModule`.