### PR TITLE
relax peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,11 +68,11 @@
     "zone.js": "^0.6.21"
   },
   "peerDependencies": {
-    "@angular/common": "^2.0.0",
-    "@angular/compiler": "^2.0.0",
-    "@angular/core": "^2.0.0",
-    "@angular/platform-browser": "^2.0.0",
-    "@angular/platform-browser-dynamic": "^2.0.0",
+    "@angular/common": ">=2.0.0",
+    "@angular/compiler": ">=2.0.0",
+    "@angular/core": ">=2.0.0",
+    "@angular/platform-browser": ">=2.0.0",
+    "@angular/platform-browser-dynamic": ">=2.0.0",
     "bootstrap": "~3.3.x"
   }
 }


### PR DESCRIPTION

Hello,

To prevent the following error  an on a project with both ng2-bs3-nodal and with angular 4.x:

```
npm shrinkwrap 

npm ERR! peer invalid: @angular/common@^2.0.0, required by ng2-bs3-modal@0.10.4
npm ERR! peer invalid: @angular/compiler@^2.0.0, required by ng2-bs3-modal@0.10.4
npm ERR! peer invalid: @angular/core@^2.0.0, required by ng2-bs3-modal@0.10.4
npm ERR! peer invalid: @angular/platform-browser@^2.0.0, required by ng2-bs3-modal@0.10.4
npm ERR! peer invalid: @angular/platform-browser-dynamic@^2.0.0, required by ng2-bs3-modal@0.10.4
```

This shouldn't be a breaking change, would it be possible to push it on npm?

Thanks a lot for reading
