### PR TITLE
Allow Angular 4 peer depedencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,11 +68,11 @@
     "zone.js": "^0.6.21"
   },
   "peerDependencies": {
-    "@angular/common": "^2.0.0",
-    "@angular/compiler": "^2.0.0",
-    "@angular/core": "^2.0.0",
-    "@angular/platform-browser": "^2.0.0",
-    "@angular/platform-browser-dynamic": "^2.0.0",
+    "@angular/common": "^2.0.0 || ^4.0.0",
+    "@angular/compiler": "^2.0.0 || ^4.0.0",
+    "@angular/core": "^2.0.0 || ^4.0.0",
+    "@angular/platform-browser": "^2.0.0 || ^4.0.0",
+    "@angular/platform-browser-dynamic": "^2.0.0 || ^4.0.0",
     "bootstrap": "~3.3.x"
   }
 }


### PR DESCRIPTION
When doing an **npm install** with this package and angular 4, we get warnings about peer dependecies but the package works fine.

However, **npm shrinkwrap** treat this warning as an error.

This change fix that.