### PR TITLE
Allow later subscriptions

### DIFF
--- a/src/ng2-bs3-modal/modal/modal.ts
+++ b/src/ng2-bs3-modal/modal/modal.ts
@@ -262,7 +262,6 @@ export class BsModalComponent implements OnInit, AfterViewInit, OnChanges, OnDes
     }
 
     private wireUpEventEmitters() {
-
         this.wireUpEventEmitter(this.onShow, this.onShowEvent$);
         this.wireUpEventEmitter(this.onOpen, this.onShown$);
         this.wireUpEventEmitter(this.onHide, this.onHide$);
@@ -271,8 +270,6 @@ export class BsModalComponent implements OnInit, AfterViewInit, OnChanges, OnDes
     }
 
     private wireUpEventEmitter<T>(emitter: EventEmitter<T>, stream$: Observable<T>) {
-        if (emitter.observers.length === 0) return;
-
         const sub = stream$.subscribe((next) => {
             this.zone.run(() => {
                 emitter.next(next);


### PR DESCRIPTION
When wiring up event emitters it should not be checked if there are already observers,
since there can always be subscriptions coming in at a later point in time.

For example if you get a reference to the modal instance via Angulars @ViewChild and then within ngAfterViewInit lifecycle hook subscribe to its events:

```
@ViewChild(BsModalComponent) modal: BsModalComponent;

public ngAfterViewInit() {
    this.modal.onClose
      .subscribe(() => {
         // do something...
      });
}
```