### PR TITLE
Allow subscribing to modal events after instantiation

### DIFF
--- a/projects/ng2-bs3-modal/src/modal/modal.component.ts
+++ b/projects/ng2-bs3-modal/src/modal/modal.component.ts
@@ -263,7 +263,6 @@ export class BsModalComponent implements OnInit, AfterViewInit, OnChanges, OnDes
     }
 
     private wireUpEventEmitters() {
-
         this.wireUpEventEmitter(this.onShow, this.onShowEvent$);
         this.wireUpEventEmitter(this.onOpen, this.onShown$);
         this.wireUpEventEmitter(this.onHide, this.onHide$);
@@ -272,10 +271,6 @@ export class BsModalComponent implements OnInit, AfterViewInit, OnChanges, OnDes
     }
 
     private wireUpEventEmitter<T>(emitter: EventEmitter<T>, stream$: Observable<T>) {
-        if (emitter.observers.length === 0) {
-            return;
-        }
-
         const sub = stream$.subscribe((next) => {
             this.zone.run(() => {
                 emitter.next(next);


### PR DESCRIPTION
When wiring up event emitters it should not be checked,
if there are already observers, since there can always be
subscriptions coming in later.

For example if one accesses the modal instance as a ViewChild
and wants to subscribe to modal events in ngAfterViewInit.